### PR TITLE
Add CI Docker Workflow

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,0 +1,28 @@
+name: CI Docker
+
+on:
+  workflow_run:
+    workflows: ["CI Test"]
+    types: [completed]
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: mr-smithers-excellent/docker-build-push@v5
+      name: Build & push Docker image
+      with:
+        image: moretonj/generate
+        tags: v1, generate:$(date +%s), pr-${{ github.event.number }}, latest
+        registry: docker.io
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+  test-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'Test CI workflow failed - not pushing to Docker.'

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -7,7 +7,6 @@ on:
     branches: [ master ]
 
 jobs:
-
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds CI Docker Workflow to push to docker.io registry, to be run on merge upon a successful CI Test build.